### PR TITLE
feat(infra): add Terraform modules for GCP infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,17 @@ htmlcov/
 .DS_Store
 Thumbs.db
 
-# Claude Code local state
-.claude/
-CLAUDE.local.md
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
 
 # Claude Code local state
 .claude/

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:k8taQAdfHrv2F/AiGV5BZBZfI+1uaq8g6O8dWzjx42c=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:XVF2ggQAZkpjLvSPbC1+AKsleIXOp10b84dWoHsEKUE=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "flowforge-terraform-state"
+    prefix = "environments/dev"
+  }
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,125 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# -----------------------------------------------------------------------------
+# Networking
+# -----------------------------------------------------------------------------
+module "networking" {
+  source = "../../modules/networking"
+
+  project_id    = var.project_id
+  region        = var.region
+  environment   = var.environment
+  subnet_cidr   = var.subnet_cidr
+  pods_cidr     = var.pods_cidr
+  services_cidr = var.services_cidr
+}
+
+# -----------------------------------------------------------------------------
+# GKE Cluster
+# -----------------------------------------------------------------------------
+module "gke" {
+  source = "../../modules/gke"
+
+  project_id                    = var.project_id
+  region                        = var.region
+  environment                   = var.environment
+  network_id                    = module.networking.network_id
+  subnet_id                     = module.networking.subnet_id
+  default_machine_type          = var.default_machine_type
+  default_node_count            = var.default_node_count
+  default_max_node_count        = var.default_max_node_count
+  stateful_machine_type         = var.stateful_machine_type
+  stateful_node_count           = var.stateful_node_count
+  master_authorized_cidr_blocks = var.master_authorized_cidr_blocks
+  enable_binary_authorization   = var.enable_binary_authorization
+  enable_spot_nodes             = var.enable_spot_nodes
+}
+
+# -----------------------------------------------------------------------------
+# IAM + Workload Identity
+# -----------------------------------------------------------------------------
+module "iam" {
+  source = "../../modules/iam"
+
+  project_id                 = var.project_id
+  environment                = var.environment
+  gke_workload_identity_pool = module.gke.workload_identity_pool
+}
+
+# -----------------------------------------------------------------------------
+# Cloud SQL (PostgreSQL)
+# -----------------------------------------------------------------------------
+module "cloudsql" {
+  source = "../../modules/cloudsql"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = var.environment
+  network_id            = module.networking.network_id
+  tier                  = var.cloudsql_tier
+  disk_size_gb          = var.cloudsql_disk_size
+  enable_ha             = var.cloudsql_enable_ha
+  backup_retention_days = var.backup_retention_days
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Memorystore (Redis)
+# -----------------------------------------------------------------------------
+module "memorystore" {
+  source = "../../modules/memorystore"
+
+  project_id     = var.project_id
+  region         = var.region
+  environment    = var.environment
+  network_id     = module.networking.network_id
+  memory_size_gb = var.memorystore_size_gb
+  tier           = var.memorystore_tier
+  auth_enabled   = var.memorystore_auth_enabled
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Artifact Registry
+# -----------------------------------------------------------------------------
+module "registry" {
+  source = "../../modules/registry"
+
+  project_id  = var.project_id
+  region      = var.region
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# Secret Manager
+# -----------------------------------------------------------------------------
+module "secrets" {
+  source = "../../modules/secrets"
+
+  project_id  = var.project_id
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# DNS (only when LB IP is available)
+# -----------------------------------------------------------------------------
+module "dns" {
+  source = "../../modules/dns"
+  count  = var.lb_ip_address != "" ? 1 : 0
+
+  project_id    = var.project_id
+  environment   = var.environment
+  domain        = var.domain
+  dns_zone_name = var.dns_zone_name
+  lb_ip_address = var.lb_ip_address
+}

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,50 @@
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = module.gke.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = module.gke.cluster_endpoint
+  sensitive   = true
+}
+
+output "cloudsql_private_ip" {
+  description = "Cloud SQL private IP address"
+  value       = module.cloudsql.private_ip
+}
+
+output "cloudsql_connection_name" {
+  description = "Cloud SQL instance connection name"
+  value       = module.cloudsql.instance_connection_name
+}
+
+output "redis_host" {
+  description = "Memorystore Redis host"
+  value       = module.memorystore.host
+}
+
+output "redis_port" {
+  description = "Memorystore Redis port"
+  value       = module.memorystore.port
+}
+
+output "registry_url" {
+  description = "Artifact Registry URL"
+  value       = module.registry.repository_url
+}
+
+output "backend_service_account" {
+  description = "Backend GCP service account email"
+  value       = module.iam.backend_service_account_email
+}
+
+output "secret_ids" {
+  description = "Secret Manager secret IDs"
+  value       = module.secrets.secret_ids
+}
+
+output "dns_name_servers" {
+  description = "DNS zone name servers"
+  value       = length(module.dns) > 0 ? module.dns[0].name_servers : []
+}

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,0 +1,12 @@
+environment           = "dev"
+region                = "us-central1"
+default_machine_type  = "e2-standard-4"
+default_node_count    = 2
+stateful_machine_type = "e2-standard-4"
+stateful_node_count   = 1
+enable_spot_nodes     = true
+cloudsql_tier         = "db-f1-micro"
+cloudsql_disk_size    = 10
+cloudsql_enable_ha    = false
+memorystore_size_gb   = 1
+memorystore_tier      = "BASIC"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,150 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+# GKE
+variable "default_machine_type" {
+  description = "Machine type for GKE default node pool"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "default_node_count" {
+  description = "Node count for GKE default pool"
+  type        = number
+  default     = 2
+}
+
+variable "default_max_node_count" {
+  description = "Max node count for autoscaler (null disables autoscaling)"
+  type        = number
+  default     = null
+}
+
+variable "stateful_machine_type" {
+  description = "Machine type for GKE stateful node pool"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "stateful_node_count" {
+  description = "Node count for GKE stateful pool"
+  type        = number
+  default     = 1
+}
+
+variable "enable_spot_nodes" {
+  description = "Use spot/preemptible nodes for cost optimization"
+  type        = bool
+  default     = true
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable Binary Authorization"
+  type        = bool
+  default     = false
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = "CIDR blocks authorized to access GKE master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+# Cloud SQL
+variable "cloudsql_tier" {
+  description = "Cloud SQL instance tier"
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "cloudsql_disk_size" {
+  description = "Cloud SQL disk size in GB"
+  type        = number
+  default     = 10
+}
+
+variable "cloudsql_enable_ha" {
+  description = "Enable Cloud SQL HA"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_days" {
+  description = "Cloud SQL backup retention days"
+  type        = number
+  default     = 7
+}
+
+# Memorystore
+variable "memorystore_size_gb" {
+  description = "Memorystore Redis memory size in GB"
+  type        = number
+  default     = 1
+}
+
+variable "memorystore_tier" {
+  description = "Memorystore Redis tier"
+  type        = string
+  default     = "BASIC"
+}
+
+variable "memorystore_auth_enabled" {
+  description = "Enable Memorystore AUTH"
+  type        = bool
+  default     = false
+}
+
+# Networking
+variable "subnet_cidr" {
+  description = "Primary subnet CIDR"
+  type        = string
+  default     = "10.0.0.0/20"
+}
+
+variable "pods_cidr" {
+  description = "Secondary range CIDR for pods"
+  type        = string
+  default     = "10.4.0.0/14"
+}
+
+variable "services_cidr" {
+  description = "Secondary range CIDR for services"
+  type        = string
+  default     = "10.8.0.0/20"
+}
+
+# DNS
+variable "domain" {
+  description = "Base domain for DNS"
+  type        = string
+  default     = "dev.flowforge.io"
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS zone name"
+  type        = string
+  default     = "flowforge-dev"
+}
+
+variable "lb_ip_address" {
+  description = "Load balancer IP address for DNS records"
+  type        = string
+  default     = ""
+}

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:k8taQAdfHrv2F/AiGV5BZBZfI+1uaq8g6O8dWzjx42c=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:XVF2ggQAZkpjLvSPbC1+AKsleIXOp10b84dWoHsEKUE=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "flowforge-terraform-state"
+    prefix = "environments/prod"
+  }
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,126 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# -----------------------------------------------------------------------------
+# Networking
+# -----------------------------------------------------------------------------
+module "networking" {
+  source = "../../modules/networking"
+
+  project_id    = var.project_id
+  region        = var.region
+  environment   = var.environment
+  subnet_cidr   = var.subnet_cidr
+  pods_cidr     = var.pods_cidr
+  services_cidr = var.services_cidr
+}
+
+# -----------------------------------------------------------------------------
+# GKE Cluster
+# -----------------------------------------------------------------------------
+module "gke" {
+  source = "../../modules/gke"
+
+  project_id                    = var.project_id
+  region                        = var.region
+  environment                   = var.environment
+  network_id                    = module.networking.network_id
+  subnet_id                     = module.networking.subnet_id
+  default_machine_type          = var.default_machine_type
+  default_node_count            = var.default_node_count
+  default_max_node_count        = var.default_max_node_count
+  stateful_machine_type         = var.stateful_machine_type
+  stateful_node_count           = var.stateful_node_count
+  master_authorized_cidr_blocks = var.master_authorized_cidr_blocks
+  enable_binary_authorization   = var.enable_binary_authorization
+  enable_spot_nodes             = var.enable_spot_nodes
+}
+
+# -----------------------------------------------------------------------------
+# IAM + Workload Identity
+# -----------------------------------------------------------------------------
+module "iam" {
+  source = "../../modules/iam"
+
+  project_id                 = var.project_id
+  environment                = var.environment
+  gke_workload_identity_pool = module.gke.workload_identity_pool
+}
+
+# -----------------------------------------------------------------------------
+# Cloud SQL (PostgreSQL)
+# -----------------------------------------------------------------------------
+module "cloudsql" {
+  source = "../../modules/cloudsql"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = var.environment
+  network_id            = module.networking.network_id
+  tier                  = var.cloudsql_tier
+  disk_size_gb          = var.cloudsql_disk_size
+  enable_ha             = var.cloudsql_enable_ha
+  backup_retention_days = var.backup_retention_days
+  deletion_protection   = true
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Memorystore (Redis)
+# -----------------------------------------------------------------------------
+module "memorystore" {
+  source = "../../modules/memorystore"
+
+  project_id     = var.project_id
+  region         = var.region
+  environment    = var.environment
+  network_id     = module.networking.network_id
+  memory_size_gb = var.memorystore_size_gb
+  tier           = var.memorystore_tier
+  auth_enabled   = var.memorystore_auth_enabled
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Artifact Registry
+# -----------------------------------------------------------------------------
+module "registry" {
+  source = "../../modules/registry"
+
+  project_id  = var.project_id
+  region      = var.region
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# Secret Manager
+# -----------------------------------------------------------------------------
+module "secrets" {
+  source = "../../modules/secrets"
+
+  project_id  = var.project_id
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# DNS (only when LB IP is available)
+# -----------------------------------------------------------------------------
+module "dns" {
+  source = "../../modules/dns"
+  count  = var.lb_ip_address != "" ? 1 : 0
+
+  project_id    = var.project_id
+  environment   = var.environment
+  domain        = var.domain
+  dns_zone_name = var.dns_zone_name
+  lb_ip_address = var.lb_ip_address
+}

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,50 @@
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = module.gke.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = module.gke.cluster_endpoint
+  sensitive   = true
+}
+
+output "cloudsql_private_ip" {
+  description = "Cloud SQL private IP address"
+  value       = module.cloudsql.private_ip
+}
+
+output "cloudsql_connection_name" {
+  description = "Cloud SQL instance connection name"
+  value       = module.cloudsql.instance_connection_name
+}
+
+output "redis_host" {
+  description = "Memorystore Redis host"
+  value       = module.memorystore.host
+}
+
+output "redis_port" {
+  description = "Memorystore Redis port"
+  value       = module.memorystore.port
+}
+
+output "registry_url" {
+  description = "Artifact Registry URL"
+  value       = module.registry.repository_url
+}
+
+output "backend_service_account" {
+  description = "Backend GCP service account email"
+  value       = module.iam.backend_service_account_email
+}
+
+output "secret_ids" {
+  description = "Secret Manager secret IDs"
+  value       = module.secrets.secret_ids
+}
+
+output "dns_name_servers" {
+  description = "DNS zone name servers"
+  value       = length(module.dns) > 0 ? module.dns[0].name_servers : []
+}

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,15 @@
+environment                 = "prod"
+region                      = "us-central1"
+default_machine_type        = "e2-standard-8"
+default_node_count          = 3
+default_max_node_count      = 6
+stateful_machine_type       = "e2-standard-8"
+stateful_node_count         = 3
+enable_binary_authorization = true
+cloudsql_tier               = "db-custom-4-8192"
+cloudsql_disk_size          = 50
+cloudsql_enable_ha          = true
+backup_retention_days       = 30
+memorystore_size_gb         = 5
+memorystore_tier            = "STANDARD_HA"
+memorystore_auth_enabled    = true

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,150 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+}
+
+# GKE
+variable "default_machine_type" {
+  description = "Machine type for GKE default node pool"
+  type        = string
+  default     = "e2-standard-8"
+}
+
+variable "default_node_count" {
+  description = "Node count for GKE default pool"
+  type        = number
+  default     = 3
+}
+
+variable "default_max_node_count" {
+  description = "Max node count for autoscaler"
+  type        = number
+  default     = 6
+}
+
+variable "stateful_machine_type" {
+  description = "Machine type for GKE stateful node pool"
+  type        = string
+  default     = "e2-standard-8"
+}
+
+variable "stateful_node_count" {
+  description = "Node count for GKE stateful pool"
+  type        = number
+  default     = 3
+}
+
+variable "enable_spot_nodes" {
+  description = "Use spot/preemptible nodes for cost optimization"
+  type        = bool
+  default     = false
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable Binary Authorization"
+  type        = bool
+  default     = true
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = "CIDR blocks authorized to access GKE master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+# Cloud SQL
+variable "cloudsql_tier" {
+  description = "Cloud SQL instance tier"
+  type        = string
+  default     = "db-custom-4-8192"
+}
+
+variable "cloudsql_disk_size" {
+  description = "Cloud SQL disk size in GB"
+  type        = number
+  default     = 50
+}
+
+variable "cloudsql_enable_ha" {
+  description = "Enable Cloud SQL HA"
+  type        = bool
+  default     = true
+}
+
+variable "backup_retention_days" {
+  description = "Cloud SQL backup retention days"
+  type        = number
+  default     = 30
+}
+
+# Memorystore
+variable "memorystore_size_gb" {
+  description = "Memorystore Redis memory size in GB"
+  type        = number
+  default     = 5
+}
+
+variable "memorystore_tier" {
+  description = "Memorystore Redis tier"
+  type        = string
+  default     = "STANDARD_HA"
+}
+
+variable "memorystore_auth_enabled" {
+  description = "Enable Memorystore AUTH"
+  type        = bool
+  default     = true
+}
+
+# Networking
+variable "subnet_cidr" {
+  description = "Primary subnet CIDR"
+  type        = string
+  default     = "10.20.0.0/20"
+}
+
+variable "pods_cidr" {
+  description = "Secondary range CIDR for pods"
+  type        = string
+  default     = "10.24.0.0/14"
+}
+
+variable "services_cidr" {
+  description = "Secondary range CIDR for services"
+  type        = string
+  default     = "10.28.0.0/20"
+}
+
+# DNS
+variable "domain" {
+  description = "Base domain for DNS"
+  type        = string
+  default     = "flowforge.io"
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS zone name"
+  type        = string
+  default     = "flowforge-prod"
+}
+
+variable "lb_ip_address" {
+  description = "Load balancer IP address for DNS records"
+  type        = string
+  default     = ""
+}

--- a/terraform/environments/prod/versions.tf
+++ b/terraform/environments/prod/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/environments/staging/.terraform.lock.hcl
+++ b/terraform/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:k8taQAdfHrv2F/AiGV5BZBZfI+1uaq8g6O8dWzjx42c=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:XVF2ggQAZkpjLvSPbC1+AKsleIXOp10b84dWoHsEKUE=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/staging/backend.tf
+++ b/terraform/environments/staging/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "flowforge-terraform-state"
+    prefix = "environments/staging"
+  }
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,0 +1,125 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# -----------------------------------------------------------------------------
+# Networking
+# -----------------------------------------------------------------------------
+module "networking" {
+  source = "../../modules/networking"
+
+  project_id    = var.project_id
+  region        = var.region
+  environment   = var.environment
+  subnet_cidr   = var.subnet_cidr
+  pods_cidr     = var.pods_cidr
+  services_cidr = var.services_cidr
+}
+
+# -----------------------------------------------------------------------------
+# GKE Cluster
+# -----------------------------------------------------------------------------
+module "gke" {
+  source = "../../modules/gke"
+
+  project_id                    = var.project_id
+  region                        = var.region
+  environment                   = var.environment
+  network_id                    = module.networking.network_id
+  subnet_id                     = module.networking.subnet_id
+  default_machine_type          = var.default_machine_type
+  default_node_count            = var.default_node_count
+  default_max_node_count        = var.default_max_node_count
+  stateful_machine_type         = var.stateful_machine_type
+  stateful_node_count           = var.stateful_node_count
+  master_authorized_cidr_blocks = var.master_authorized_cidr_blocks
+  enable_binary_authorization   = var.enable_binary_authorization
+  enable_spot_nodes             = var.enable_spot_nodes
+}
+
+# -----------------------------------------------------------------------------
+# IAM + Workload Identity
+# -----------------------------------------------------------------------------
+module "iam" {
+  source = "../../modules/iam"
+
+  project_id                 = var.project_id
+  environment                = var.environment
+  gke_workload_identity_pool = module.gke.workload_identity_pool
+}
+
+# -----------------------------------------------------------------------------
+# Cloud SQL (PostgreSQL)
+# -----------------------------------------------------------------------------
+module "cloudsql" {
+  source = "../../modules/cloudsql"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = var.environment
+  network_id            = module.networking.network_id
+  tier                  = var.cloudsql_tier
+  disk_size_gb          = var.cloudsql_disk_size
+  enable_ha             = var.cloudsql_enable_ha
+  backup_retention_days = var.backup_retention_days
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Memorystore (Redis)
+# -----------------------------------------------------------------------------
+module "memorystore" {
+  source = "../../modules/memorystore"
+
+  project_id     = var.project_id
+  region         = var.region
+  environment    = var.environment
+  network_id     = module.networking.network_id
+  memory_size_gb = var.memorystore_size_gb
+  tier           = var.memorystore_tier
+  auth_enabled   = var.memorystore_auth_enabled
+
+  depends_on = [module.networking]
+}
+
+# -----------------------------------------------------------------------------
+# Artifact Registry
+# -----------------------------------------------------------------------------
+module "registry" {
+  source = "../../modules/registry"
+
+  project_id  = var.project_id
+  region      = var.region
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# Secret Manager
+# -----------------------------------------------------------------------------
+module "secrets" {
+  source = "../../modules/secrets"
+
+  project_id  = var.project_id
+  environment = var.environment
+}
+
+# -----------------------------------------------------------------------------
+# DNS (only when LB IP is available)
+# -----------------------------------------------------------------------------
+module "dns" {
+  source = "../../modules/dns"
+  count  = var.lb_ip_address != "" ? 1 : 0
+
+  project_id    = var.project_id
+  environment   = var.environment
+  domain        = var.domain
+  dns_zone_name = var.dns_zone_name
+  lb_ip_address = var.lb_ip_address
+}

--- a/terraform/environments/staging/outputs.tf
+++ b/terraform/environments/staging/outputs.tf
@@ -1,0 +1,50 @@
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = module.gke.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = module.gke.cluster_endpoint
+  sensitive   = true
+}
+
+output "cloudsql_private_ip" {
+  description = "Cloud SQL private IP address"
+  value       = module.cloudsql.private_ip
+}
+
+output "cloudsql_connection_name" {
+  description = "Cloud SQL instance connection name"
+  value       = module.cloudsql.instance_connection_name
+}
+
+output "redis_host" {
+  description = "Memorystore Redis host"
+  value       = module.memorystore.host
+}
+
+output "redis_port" {
+  description = "Memorystore Redis port"
+  value       = module.memorystore.port
+}
+
+output "registry_url" {
+  description = "Artifact Registry URL"
+  value       = module.registry.repository_url
+}
+
+output "backend_service_account" {
+  description = "Backend GCP service account email"
+  value       = module.iam.backend_service_account_email
+}
+
+output "secret_ids" {
+  description = "Secret Manager secret IDs"
+  value       = module.secrets.secret_ids
+}
+
+output "dns_name_servers" {
+  description = "DNS zone name servers"
+  value       = length(module.dns) > 0 ? module.dns[0].name_servers : []
+}

--- a/terraform/environments/staging/terraform.tfvars
+++ b/terraform/environments/staging/terraform.tfvars
@@ -1,0 +1,11 @@
+environment           = "staging"
+region                = "us-central1"
+default_machine_type  = "e2-standard-4"
+default_node_count    = 3
+stateful_machine_type = "e2-standard-4"
+stateful_node_count   = 1
+cloudsql_tier         = "db-custom-2-4096"
+cloudsql_disk_size    = 20
+cloudsql_enable_ha    = false
+memorystore_size_gb   = 2
+memorystore_tier      = "BASIC"

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,0 +1,150 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "staging"
+}
+
+# GKE
+variable "default_machine_type" {
+  description = "Machine type for GKE default node pool"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "default_node_count" {
+  description = "Node count for GKE default pool"
+  type        = number
+  default     = 3
+}
+
+variable "default_max_node_count" {
+  description = "Max node count for autoscaler (null disables autoscaling)"
+  type        = number
+  default     = null
+}
+
+variable "stateful_machine_type" {
+  description = "Machine type for GKE stateful node pool"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "stateful_node_count" {
+  description = "Node count for GKE stateful pool"
+  type        = number
+  default     = 1
+}
+
+variable "enable_spot_nodes" {
+  description = "Use spot/preemptible nodes for cost optimization"
+  type        = bool
+  default     = false
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable Binary Authorization"
+  type        = bool
+  default     = false
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = "CIDR blocks authorized to access GKE master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+# Cloud SQL
+variable "cloudsql_tier" {
+  description = "Cloud SQL instance tier"
+  type        = string
+  default     = "db-custom-2-4096"
+}
+
+variable "cloudsql_disk_size" {
+  description = "Cloud SQL disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "cloudsql_enable_ha" {
+  description = "Enable Cloud SQL HA"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_days" {
+  description = "Cloud SQL backup retention days"
+  type        = number
+  default     = 7
+}
+
+# Memorystore
+variable "memorystore_size_gb" {
+  description = "Memorystore Redis memory size in GB"
+  type        = number
+  default     = 2
+}
+
+variable "memorystore_tier" {
+  description = "Memorystore Redis tier"
+  type        = string
+  default     = "BASIC"
+}
+
+variable "memorystore_auth_enabled" {
+  description = "Enable Memorystore AUTH"
+  type        = bool
+  default     = false
+}
+
+# Networking
+variable "subnet_cidr" {
+  description = "Primary subnet CIDR"
+  type        = string
+  default     = "10.10.0.0/20"
+}
+
+variable "pods_cidr" {
+  description = "Secondary range CIDR for pods"
+  type        = string
+  default     = "10.14.0.0/14"
+}
+
+variable "services_cidr" {
+  description = "Secondary range CIDR for services"
+  type        = string
+  default     = "10.18.0.0/20"
+}
+
+# DNS
+variable "domain" {
+  description = "Base domain for DNS"
+  type        = string
+  default     = "staging.flowforge.io"
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS zone name"
+  type        = string
+  default     = "flowforge-staging"
+}
+
+variable "lb_ip_address" {
+  description = "Load balancer IP address for DNS records"
+  type        = string
+  default     = ""
+}

--- a/terraform/environments/staging/versions.tf
+++ b/terraform/environments/staging/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/cloudsql/main.tf
+++ b/terraform/modules/cloudsql/main.tf
@@ -1,0 +1,99 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cloud SQL PostgreSQL 16 Instance
+# -----------------------------------------------------------------------------
+resource "google_sql_database_instance" "primary" {
+  name                = "flowforge-${var.environment}-pg"
+  project             = var.project_id
+  region              = var.region
+  database_version    = "POSTGRES_16"
+  deletion_protection = var.deletion_protection
+
+  settings {
+    tier              = var.tier
+    disk_size         = var.disk_size_gb
+    disk_type         = "PD_SSD"
+    disk_autoresize   = true
+    availability_type = var.enable_ha ? "REGIONAL" : "ZONAL"
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = var.network_id
+      enable_private_path_for_google_cloud_services = true
+    }
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+      start_time                     = "03:00"
+      transaction_log_retention_days = var.backup_retention_days
+
+      backup_retention_settings {
+        retained_backups = var.backup_retention_days
+      }
+    }
+
+    maintenance_window {
+      day          = 7 # Sunday
+      hour         = 3
+      update_track = "stable"
+    }
+
+    dynamic "database_flags" {
+      for_each = var.database_flags
+      content {
+        name  = database_flags.key
+        value = database_flags.value
+      }
+    }
+
+    user_labels = local.labels
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+resource "google_sql_database" "flowforge" {
+  name     = "flowforge"
+  project  = var.project_id
+  instance = google_sql_database_instance.primary.name
+}
+
+# -----------------------------------------------------------------------------
+# Database Users
+# -----------------------------------------------------------------------------
+resource "google_sql_user" "app" {
+  name     = "flowforge_app"
+  project  = var.project_id
+  instance = google_sql_database_instance.primary.name
+  type     = "BUILT_IN"
+
+  # Password managed via Secret Manager — set out-of-band
+  password = "CHANGE_ME_VIA_SECRET_MANAGER"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+resource "google_sql_user" "migrate" {
+  name     = "flowforge_migrate"
+  project  = var.project_id
+  instance = google_sql_database_instance.primary.name
+  type     = "BUILT_IN"
+
+  # Password managed via Secret Manager — set out-of-band
+  password = "CHANGE_ME_VIA_SECRET_MANAGER"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}

--- a/terraform/modules/cloudsql/outputs.tf
+++ b/terraform/modules/cloudsql/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_name" {
+  description = "Cloud SQL instance name"
+  value       = google_sql_database_instance.primary.name
+}
+
+output "instance_connection_name" {
+  description = "Cloud SQL instance connection name"
+  value       = google_sql_database_instance.primary.connection_name
+}
+
+output "private_ip" {
+  description = "Cloud SQL private IP address"
+  value       = google_sql_database_instance.primary.private_ip_address
+}
+
+output "database_name" {
+  description = "Database name"
+  value       = google_sql_database.flowforge.name
+}

--- a/terraform/modules/cloudsql/variables.tf
+++ b/terraform/modules/cloudsql/variables.tf
@@ -1,0 +1,57 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "network_id" {
+  description = "VPC network ID for private IP connectivity"
+  type        = string
+}
+
+variable "tier" {
+  description = "Cloud SQL machine tier"
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "disk_size_gb" {
+  description = "Disk size in GB"
+  type        = number
+  default     = 10
+}
+
+variable "enable_ha" {
+  description = "Enable high availability (regional) deployment"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_days" {
+  description = "Number of days to retain backups"
+  type        = number
+  default     = 7
+}
+
+variable "database_flags" {
+  description = "Map of database flags to set"
+  type        = map(string)
+  default = {
+    max_connections = "200"
+  }
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/dns/main.tf
+++ b/terraform/modules/dns/main.tf
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# Cloud DNS Managed Zone
+# -----------------------------------------------------------------------------
+resource "google_dns_managed_zone" "flowforge" {
+  name        = var.dns_zone_name
+  project     = var.project_id
+  dns_name    = "${var.domain}."
+  description = "FlowForge DNS zone (${var.environment})"
+
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DNS A Records
+# -----------------------------------------------------------------------------
+
+# App subdomain (frontend + embed)
+resource "google_dns_record_set" "app" {
+  name         = "app.${google_dns_managed_zone.flowforge.dns_name}"
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.flowforge.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [var.lb_ip_address]
+}
+
+# API subdomain (backend)
+resource "google_dns_record_set" "api" {
+  name         = "api.${google_dns_managed_zone.flowforge.dns_name}"
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.flowforge.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [var.lb_ip_address]
+}

--- a/terraform/modules/dns/outputs.tf
+++ b/terraform/modules/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_name" {
+  description = "Cloud DNS managed zone name"
+  value       = google_dns_managed_zone.flowforge.name
+}
+
+output "name_servers" {
+  description = "Cloud DNS name servers for the zone"
+  value       = google_dns_managed_zone.flowforge.name_servers
+}

--- a/terraform/modules/dns/variables.tf
+++ b/terraform/modules/dns/variables.tf
@@ -1,0 +1,24 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "domain" {
+  description = "Base domain for DNS records"
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS managed zone name"
+  type        = string
+}
+
+variable "lb_ip_address" {
+  description = "Load balancer IP address for DNS A records"
+  type        = string
+}

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -1,0 +1,181 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# GKE Cluster
+# -----------------------------------------------------------------------------
+resource "google_container_cluster" "primary" {
+  name     = "flowforge-${var.environment}"
+  project  = var.project_id
+  location = var.region
+
+  network    = var.network_id
+  subnetwork = var.subnet_id
+
+  # We manage node pools separately
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  # Private cluster configuration
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = "172.16.0.0/28"
+  }
+
+  # Master authorized networks
+  dynamic "master_authorized_networks_config" {
+    for_each = length(var.master_authorized_cidr_blocks) > 0 ? [1] : []
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.master_authorized_cidr_blocks
+        content {
+          cidr_block   = cidr_blocks.value.cidr_block
+          display_name = cidr_blocks.value.display_name
+        }
+      }
+    }
+  }
+
+  # IP allocation policy for VPC-native cluster
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  # Workload Identity
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  # Release channel — stable
+  release_channel {
+    channel = "STABLE"
+  }
+
+  # Binary Authorization
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [1] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
+  # Logging and monitoring
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+    managed_prometheus {
+      enabled = true
+    }
+  }
+
+  resource_labels = local.labels
+
+  # Prevent accidental deletion
+  deletion_protection = var.environment == "prod" ? true : false
+}
+
+# -----------------------------------------------------------------------------
+# Default Node Pool — application workloads
+# -----------------------------------------------------------------------------
+resource "google_container_node_pool" "default" {
+  name     = "default"
+  project  = var.project_id
+  location = var.region
+  cluster  = google_container_cluster.primary.name
+
+  initial_node_count = var.default_node_count
+
+  # Autoscaling (only when max is set)
+  dynamic "autoscaling" {
+    for_each = var.default_max_node_count != null ? [1] : []
+    content {
+      min_node_count = var.default_node_count
+      max_node_count = var.default_max_node_count
+    }
+  }
+
+  node_config {
+    machine_type = var.default_machine_type
+    spot         = var.enable_spot_nodes
+
+    disk_size_gb = 100
+    disk_type    = "pd-ssd"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    labels = merge(local.labels, {
+      "flowforge.io/pool" = "default"
+    })
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Stateful Node Pool — ClickHouse, Materialize, Redpanda
+# -----------------------------------------------------------------------------
+resource "google_container_node_pool" "stateful" {
+  name     = "stateful"
+  project  = var.project_id
+  location = var.region
+  cluster  = google_container_cluster.primary.name
+
+  node_count = var.stateful_node_count
+
+  node_config {
+    machine_type = var.stateful_machine_type
+
+    disk_size_gb = 200
+    disk_type    = "pd-ssd"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    labels = merge(local.labels, {
+      "flowforge.io/pool" = "stateful"
+    })
+
+    taint {
+      key    = "flowforge.io/pool"
+      value  = "stateful"
+      effect = "NO_SCHEDULE"
+    }
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+}

--- a/terraform/modules/gke/outputs.tf
+++ b/terraform/modules/gke/outputs.tf
@@ -1,0 +1,21 @@
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = google_container_cluster.primary.name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = google_container_cluster.primary.endpoint
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "GKE cluster CA certificate"
+  value       = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "workload_identity_pool" {
+  description = "Workload Identity pool for GKE"
+  value       = "${var.project_id}.svc.id.goog"
+}

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -1,0 +1,75 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "network_id" {
+  description = "VPC network ID"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "GKE subnet ID"
+  type        = string
+}
+
+variable "default_machine_type" {
+  description = "Machine type for default node pool"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "default_node_count" {
+  description = "Initial node count for default pool"
+  type        = number
+  default     = 2
+}
+
+variable "default_max_node_count" {
+  description = "Max node count for default pool autoscaler (null disables autoscaling)"
+  type        = number
+  default     = null
+}
+
+variable "stateful_machine_type" {
+  description = "Machine type for stateful node pool (ClickHouse, Materialize, Redpanda)"
+  type        = string
+  default     = "e2-standard-8"
+}
+
+variable "stateful_node_count" {
+  description = "Node count for stateful pool"
+  type        = number
+  default     = 2
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = "CIDR blocks authorized to access the GKE master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable Binary Authorization (prod only)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spot_nodes" {
+  description = "Use spot/preemptible nodes for default pool (dev cost optimization)"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,83 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+
+  service_accounts = {
+    backend     = "flowforge-backend"
+    frontend    = "flowforge-frontend"
+    clickhouse  = "flowforge-clickhouse"
+    materialize = "flowforge-materialize"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# GCP Service Accounts
+# -----------------------------------------------------------------------------
+resource "google_service_account" "backend" {
+  account_id   = "${local.service_accounts.backend}-${var.environment}"
+  display_name = "FlowForge Backend (${var.environment})"
+  project      = var.project_id
+}
+
+resource "google_service_account" "frontend" {
+  account_id   = "${local.service_accounts.frontend}-${var.environment}"
+  display_name = "FlowForge Frontend (${var.environment})"
+  project      = var.project_id
+}
+
+resource "google_service_account" "clickhouse" {
+  account_id   = "${local.service_accounts.clickhouse}-${var.environment}"
+  display_name = "FlowForge ClickHouse (${var.environment})"
+  project      = var.project_id
+}
+
+resource "google_service_account" "materialize" {
+  account_id   = "${local.service_accounts.materialize}-${var.environment}"
+  display_name = "FlowForge Materialize (${var.environment})"
+  project      = var.project_id
+}
+
+# -----------------------------------------------------------------------------
+# IAM Roles for Backend SA
+# -----------------------------------------------------------------------------
+resource "google_project_iam_member" "backend_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
+resource "google_project_iam_member" "backend_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
+# -----------------------------------------------------------------------------
+# Workload Identity Bindings (K8s SA → GCP SA)
+# -----------------------------------------------------------------------------
+resource "google_service_account_iam_member" "backend_workload_identity" {
+  service_account_id = google_service_account.backend.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gke_workload_identity_pool}[flowforge/flowforge-backend]"
+}
+
+resource "google_service_account_iam_member" "frontend_workload_identity" {
+  service_account_id = google_service_account.frontend.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gke_workload_identity_pool}[flowforge/flowforge-frontend]"
+}
+
+resource "google_service_account_iam_member" "clickhouse_workload_identity" {
+  service_account_id = google_service_account.clickhouse.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gke_workload_identity_pool}[flowforge-data/clickhouse]"
+}
+
+resource "google_service_account_iam_member" "materialize_workload_identity" {
+  service_account_id = google_service_account.materialize.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gke_workload_identity_pool}[flowforge-data/materialize]"
+}

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,19 @@
+output "backend_service_account_email" {
+  description = "Backend GCP service account email"
+  value       = google_service_account.backend.email
+}
+
+output "frontend_service_account_email" {
+  description = "Frontend GCP service account email"
+  value       = google_service_account.frontend.email
+}
+
+output "clickhouse_service_account_email" {
+  description = "ClickHouse GCP service account email"
+  value       = google_service_account.clickhouse.email
+}
+
+output "materialize_service_account_email" {
+  description = "Materialize GCP service account email"
+  value       = google_service_account.materialize.email
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "gke_workload_identity_pool" {
+  description = "GKE Workload Identity pool (format: <project_id>.svc.id.goog)"
+  type        = string
+}

--- a/terraform/modules/memorystore/main.tf
+++ b/terraform/modules/memorystore/main.tf
@@ -1,0 +1,30 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Memorystore Redis Instance
+# -----------------------------------------------------------------------------
+resource "google_redis_instance" "cache" {
+  name           = "flowforge-${var.environment}-redis"
+  project        = var.project_id
+  region         = var.region
+  tier           = var.tier
+  memory_size_gb = var.memory_size_gb
+  redis_version  = var.redis_version
+
+  authorized_network = var.network_id
+  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+
+  auth_enabled = var.auth_enabled
+
+  redis_configs = {
+    maxmemory-policy = "allkeys-lru"
+  }
+
+  labels = local.labels
+}

--- a/terraform/modules/memorystore/outputs.tf
+++ b/terraform/modules/memorystore/outputs.tf
@@ -1,0 +1,15 @@
+output "host" {
+  description = "Redis instance host IP"
+  value       = google_redis_instance.cache.host
+}
+
+output "port" {
+  description = "Redis instance port"
+  value       = google_redis_instance.cache.port
+}
+
+output "auth_string" {
+  description = "Redis AUTH string (empty if auth not enabled)"
+  value       = google_redis_instance.cache.auth_string
+  sensitive   = true
+}

--- a/terraform/modules/memorystore/variables.tf
+++ b/terraform/modules/memorystore/variables.tf
@@ -1,0 +1,43 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "network_id" {
+  description = "VPC network ID for private connectivity"
+  type        = string
+}
+
+variable "memory_size_gb" {
+  description = "Redis memory size in GB"
+  type        = number
+  default     = 1
+}
+
+variable "tier" {
+  description = "Memorystore tier (BASIC or STANDARD_HA)"
+  type        = string
+  default     = "BASIC"
+}
+
+variable "redis_version" {
+  description = "Redis version"
+  type        = string
+  default     = "REDIS_7_0"
+}
+
+variable "auth_enabled" {
+  description = "Enable AUTH for Redis connections"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,142 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC
+# -----------------------------------------------------------------------------
+resource "google_compute_network" "vpc" {
+  name                    = "flowforge-${var.environment}-vpc"
+  project                 = var.project_id
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+# -----------------------------------------------------------------------------
+# Subnet with secondary ranges for GKE pods and services
+# -----------------------------------------------------------------------------
+resource "google_compute_subnetwork" "gke" {
+  name                     = "flowforge-${var.environment}-gke-subnet"
+  project                  = var.project_id
+  region                   = var.region
+  network                  = google_compute_network.vpc.id
+  ip_cidr_range            = var.subnet_cidr
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = var.pods_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = var.services_cidr
+  }
+
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cloud Router + NAT (outbound internet for private GKE nodes)
+# -----------------------------------------------------------------------------
+resource "google_compute_router" "router" {
+  name    = "flowforge-${var.environment}-router"
+  project = var.project_id
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "flowforge-${var.environment}-nat"
+  project                            = var.project_id
+  region                             = var.region
+  router                             = google_compute_router.router.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Private Service Access (Cloud SQL + Memorystore private connectivity)
+# -----------------------------------------------------------------------------
+resource "google_compute_global_address" "private_service_access" {
+  name          = "flowforge-${var.environment}-psa"
+  project       = var.project_id
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.vpc.id
+}
+
+resource "google_service_networking_connection" "private_service_access" {
+  network                 = google_compute_network.vpc.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_access.name]
+}
+
+# -----------------------------------------------------------------------------
+# Firewall rules
+# -----------------------------------------------------------------------------
+
+# Allow internal traffic within VPC
+resource "google_compute_firewall" "allow_internal" {
+  name    = "flowforge-${var.environment}-allow-internal"
+  project = var.project_id
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [var.subnet_cidr, var.pods_cidr, var.services_cidr]
+  priority      = 1000
+}
+
+# Allow GCP health check probes
+resource "google_compute_firewall" "allow_health_checks" {
+  name    = "flowforge-${var.environment}-allow-health-checks"
+  project = var.project_id
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+  }
+
+  # GCP health check source ranges
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  priority      = 1000
+}
+
+# Deny all ingress from internet
+resource "google_compute_firewall" "deny_ingress" {
+  name    = "flowforge-${var.environment}-deny-ingress"
+  project = var.project_id
+  network = google_compute_network.vpc.id
+
+  deny {
+    protocol = "all"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  priority      = 65534
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,24 @@
+output "network_id" {
+  description = "VPC network ID"
+  value       = google_compute_network.vpc.id
+}
+
+output "network_name" {
+  description = "VPC network name"
+  value       = google_compute_network.vpc.name
+}
+
+output "subnet_id" {
+  description = "GKE subnet ID"
+  value       = google_compute_subnetwork.gke.id
+}
+
+output "subnet_name" {
+  description = "GKE subnet name"
+  value       = google_compute_subnetwork.gke.name
+}
+
+output "private_service_access_address" {
+  description = "Private Service Access address range name"
+  value       = google_compute_global_address.private_service_access.name
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,32 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "Primary subnet CIDR for GKE nodes"
+  type        = string
+  default     = "10.0.0.0/20"
+}
+
+variable "pods_cidr" {
+  description = "Secondary range CIDR for GKE pods"
+  type        = string
+  default     = "10.4.0.0/14"
+}
+
+variable "services_cidr" {
+  description = "Secondary range CIDR for GKE services"
+  type        = string
+  default     = "10.8.0.0/20"
+}

--- a/terraform/modules/registry/main.tf
+++ b/terraform/modules/registry/main.tf
@@ -1,0 +1,30 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Artifact Registry — Docker Repository
+# -----------------------------------------------------------------------------
+resource "google_artifact_registry_repository" "flowforge" {
+  repository_id = "flowforge"
+  project       = var.project_id
+  location      = var.region
+  format        = "DOCKER"
+  description   = "FlowForge Docker images (${var.environment})"
+
+  labels = local.labels
+
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "2592000s" # 30 days
+    }
+  }
+}

--- a/terraform/modules/registry/outputs.tf
+++ b/terraform/modules/registry/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_id" {
+  description = "Artifact Registry repository ID"
+  value       = google_artifact_registry_repository.flowforge.repository_id
+}
+
+output "repository_url" {
+  description = "Artifact Registry repository URL"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.flowforge.repository_id}"
+}

--- a/terraform/modules/registry/variables.tf
+++ b/terraform/modules/registry/variables.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,23 @@
+locals {
+  labels = {
+    environment = var.environment
+    project     = "flowforge"
+    managed-by  = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Secret Manager Secrets
+# Creates secret resources only — values are populated out-of-band (manually or via CI)
+# -----------------------------------------------------------------------------
+resource "google_secret_manager_secret" "secrets" {
+  for_each  = toset(var.secret_names)
+  secret_id = "${var.environment}-${each.value}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = local.labels
+}

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_ids" {
+  description = "Map of secret name to Secret Manager secret ID"
+  value       = { for name, secret in google_secret_manager_secret.secrets : name => secret.id }
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,24 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "secret_names" {
+  description = "List of secret names to create in Secret Manager"
+  type        = list(string)
+  default = [
+    "cloudsql-app-password",
+    "cloudsql-migrate-password",
+    "keycloak-admin-password",
+    "keycloak-db-password",
+    "redis-auth-string",
+    "clickhouse-password",
+    "jwt-signing-key",
+    "api-key-encryption-key",
+  ]
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implement 8 Terraform modules: networking, iam, gke, cloudsql, memorystore, registry, secrets, dns
- Add 3 environment configs (dev, staging, prod) with per-environment sizing via tfvars
- Add root versions.tf with Google provider pins (~> 5.0)
- Add Terraform entries to .gitignore

## Details
- All modules are environment-agnostic — differences controlled entirely via variables
- Private networking enforced: no public IPs on GKE nodes, Cloud SQL, or Memorystore
- Workload Identity bindings for pod-level GCP IAM (no JSON key files)
- Secret Manager secrets created without values (populated out-of-band)
- DNS module conditionally enabled (only when LB IP is available)
- Prod: HA Cloud SQL, autoscaling GKE, STANDARD_HA Redis, Binary Authorization, deletion protection
- Dev: spot nodes, db-f1-micro, minimal sizing for cost optimization
- `terraform fmt -check -recursive` and `terraform validate` pass on all environments

## Test plan
- [x] `terraform fmt -check -recursive terraform/` passes
- [x] `terraform validate` passes in dev, staging, and prod (with `-backend=false`)
- [ ] Review module structure matches `terraform/agents.md` specification
- [ ] Verify no hardcoded project IDs, IPs, or credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)