### PR TITLE
fix: Bytewax v0.21 compat + make Materialize optional

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,4 +44,7 @@ RUN echo 'alias ll="ls -alF"' >> ~/.zshrc \
     && echo 'alias logs="docker compose logs -f"' >> ~/.zshrc \
     && echo 'export PATH="/workspace/frontend/node_modules/.bin:$PATH"' >> ~/.zshrc
 
+RUN mkdir -p /home/vscode/.cache && chown -R vscode:vscode /home/vscode/.cache
+
+
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -122,7 +122,8 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
       "plugins": "git docker-compose python node npm"
-    }
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
   // ── Remote User ───────────────────────────────────────────────────

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -57,8 +57,6 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
-      materialize:
-        condition: service_healthy
     networks:
       - flowforge
 
@@ -150,6 +148,8 @@ services:
 
   # ── Materialize ─────────────────────────────────────────────────────
   materialize:
+    profiles:
+      - streaming
     image: materialize/materialized:latest
     restart: unless-stopped
     volumes:
@@ -169,6 +169,8 @@ services:
 
   # ── Init-Materialize (one-shot) ────────────────────────────────────
   init-materialize:
+    profiles:
+      - streaming
     image: postgres:16-alpine
     depends_on:
       materialize:

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -30,11 +30,16 @@ until curl -sf http://redpanda:9644/v1/status/ready >/dev/null 2>&1; do
 done
 echo "✅ Redpanda is ready"
 
-echo "⏳ Waiting for Materialize..."
-until pg_isready -h materialize -p 6875 -U materialize -q 2>/dev/null; do
-  sleep 1
-done
-echo "✅ Materialize is ready"
+# Materialize is behind the "streaming" profile — only wait if reachable
+if pg_isready -h materialize -p 6875 -U materialize -q 2>/dev/null; then
+  echo "⏳ Waiting for Materialize..."
+  until pg_isready -h materialize -p 6875 -U materialize -q 2>/dev/null; do
+    sleep 1
+  done
+  echo "✅ Materialize is ready"
+else
+  echo "⏭️  Materialize not running (enable with: docker compose --profile streaming up)"
+fi
 
 echo ""
 echo "🚀 All infrastructure services are up!"


### PR DESCRIPTION
## Summary
- Update Bytewax flows (`vwap.py`, `volatility.py`) for v0.21 API compatibility (`stateful_map` signature, `fold_window`, `OFFSET_END`, `StdOutSink`)
- Move Materialize and init-materialize behind a `streaming` Docker Compose profile so the devcontainer starts without them
- Fix `post-start.sh` to skip the Materialize wait when the service isn't running, instead of blocking forever

## Test plan
- [ ] Verify devcontainer starts cleanly without Materialize
- [ ] Verify `docker compose --profile streaming up` still brings up Materialize when needed
- [ ] Verify Bytewax flows import and run against Redpanda with v0.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)