### PR TITLE
docs: add ADR/RFC structure with 7 seed architecture decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,10 @@ flowforge/
 ├── .github/workflows/               # CI/CD (7 workflows)
 ├── .devcontainer/                   # Docker Compose + init scripts + Keycloak realm
 ├── scripts/                         # Dev utilities (start-pipeline, seed, etc.)
-├── docs/                            # Focused guides
+├── docs/                            # Documentation
+│   ├── decisions/                   # Architecture Decision Records (ADRs)
+│   ├── rfcs/                        # Proposals for significant changes
+│   ├── archive/                     # Completed planning docs (historical)
 │   ├── node-type-guide.md           # Node type checklist + query merging rules
 │   ├── multi-tenancy.md             # Tenant isolation patterns
 │   └── serving-layer.md             # Table catalog + query router dispatch
@@ -1090,6 +1093,8 @@ In production, PostgreSQL and Redis are GCP managed services (Cloud SQL, Memorys
 | Document | Description |
 |----------|-------------|
 | [CLAUDE.md](./CLAUDE.md) | Agent coding rules (architectural constraints, conventions) |
+| [docs/decisions/](./docs/decisions/) | Architecture Decision Records — why key technical decisions were made |
+| [docs/rfcs/](./docs/rfcs/) | Proposals for significant changes (pre-decision) |
 | [docs/node-type-guide.md](./docs/node-type-guide.md) | Node type checklist, schema propagation rules, query merging |
 | [docs/multi-tenancy.md](./docs/multi-tenancy.md) | Tenant isolation patterns, code examples, test requirements |
 | [docs/serving-layer.md](./docs/serving-layer.md) | Table catalog, query router dispatch rules, SQL dialects |
@@ -1097,6 +1102,7 @@ In production, PostgreSQL and Redis are GCP managed services (Cloud SQL, Memorys
 | [backend/app/api/CLAUDE.md](./backend/app/api/CLAUDE.md) | API route conventions, endpoint catalog, auth patterns |
 | [terraform/agents.md](./terraform/agents.md) | Terraform module structure and GCP infrastructure |
 | [.github/workflows/agents.md](./.github/workflows/agents.md) | CI/CD workflow documentation |
+| [docs/archive/](./docs/archive/) | Completed planning docs (historical reference) |
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
 # FlowForge — Agent Rules
 
-> Architecture (archived): [`docs/archive/planning.md`](./docs/archive/planning.md) | Spec (archived): [`docs/archive/Application plan.md`](./docs/archive/Application%20plan.md)
+> Decisions: [`docs/decisions/`](./docs/decisions/) | RFCs: [`docs/rfcs/`](./docs/rfcs/) | Archive: [`docs/archive/`](./docs/archive/)
 > Every agent in this repo MUST follow these rules without exception.
 
 ## Project Identity

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,9 +4,31 @@
 
 ## Purpose
 
-Focused technical guides for specific cross-cutting concerns. These supplement the per-directory `agents.md` files with deeper dives.
+Technical reference guides, architecture decision records, and proposal documents. Organized into four categories with distinct lifecycles.
 
-## Document Catalog
+## Directory Structure
+
+```
+docs/
+├── decisions/       # ADRs — immutable records of key technical decisions
+├── rfcs/            # Proposals for significant changes (pre-decision)
+├── archive/         # Completed planning docs (legacy reference only)
+├── node-type-guide.md
+├── multi-tenancy.md
+├── serving-layer.md
+└── agents.md
+```
+
+## Document Types
+
+| Type | Location | Lifecycle | Purpose |
+|------|----------|-----------|---------|
+| **Reference Guides** | `docs/*.md` | Living — edited in place | Cross-cutting technical patterns (node types, tenancy, serving layer) |
+| **ADRs** | `docs/decisions/` | Immutable — superseded, never edited | Record *why* key technical decisions were made |
+| **RFCs** | `docs/rfcs/` | Proposed -> Accepted/Rejected | Proposals for significant changes needing discussion |
+| **Archive** | `docs/archive/` | Frozen | Legacy planning docs, historical reference only |
+
+## Reference Guides
 
 | Document | Audience | Covers |
 |----------|----------|--------|
@@ -27,3 +49,5 @@ Focused technical guides for specific cross-cutting concerns. These supplement t
 - **Do not duplicate `agents.md` content** — docs complement agents.md, they don't replace it. If a rule belongs in a directory's agents.md, put it there.
 - **Do not create new docs without clear need** — every doc should answer a specific question that multiple agents encounter. One-off notes belong in the relevant agents.md.
 - **No auto-generated API docs** — the Swagger UI at `/docs` is the API reference. These docs cover architectural patterns, not endpoint signatures.
+- **ADRs are immutable** — never edit an accepted ADR. Write a new one that supersedes it.
+- **RFCs produce ADRs** — when an RFC is accepted, extract key decisions into `docs/decisions/`.

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,21 @@
+# NNNN: Title
+
+**Status:** Proposed | Accepted | Superseded by [NNNN](./NNNN-title.md) | Deprecated
+**Date:** YYYY-MM-DD
+**Deciders:** Who was involved in making the decision
+
+## Context
+
+What is the problem or situation that requires a decision? What forces are at play?
+
+## Decision
+
+What is the change that we're making? State it clearly and directly.
+
+## Alternatives Considered
+
+What other options were evaluated? Why were they not chosen?
+
+## Consequences
+
+What becomes easier or harder as a result of this decision? Include both positive and negative consequences.

--- a/docs/decisions/0001-sqlglot-over-dataframes.md
+++ b/docs/decisions/0001-sqlglot-over-dataframes.md
@@ -1,0 +1,39 @@
+# 0001: Use SQLGlot for Query Compilation Instead of DataFrames
+
+**Status:** Accepted
+**Date:** 2025-10-01
+**Deciders:** Architecture team
+
+## Context
+
+FlowForge compiles visual canvas workflows into executable queries against ClickHouse, Materialize, and Redis. The two main approaches were:
+
+1. **DataFrame execution** (Pandas/Polars) — pull data into Python, transform in memory, return results
+2. **SQL compilation** (SQLGlot) — translate the canvas DAG into SQL, push execution to the backing store
+
+The canvas supports 17+ node types (filter, join, group_by, pivot, window functions, etc.) that must compose arbitrarily.
+
+## Decision
+
+Use **SQLGlot** to compile canvas workflows into SQL. Pandas/Polars are only used for formatting preview results and test fixtures — never for query execution.
+
+SQLGlot provides:
+- AST-based SQL generation with dialect-specific output (ClickHouse, PostgreSQL)
+- Parameterized value injection (prevents SQL injection without string concatenation)
+- Composable expression trees that map naturally to the canvas DAG
+- Query merging: adjacent compatible nodes (Filter -> Select -> Sort) collapse into a single SQL query
+
+## Alternatives Considered
+
+**Pandas/Polars DataFrames**: Simpler to implement initially, but doesn't scale. Pulling millions of rows from ClickHouse into Python memory defeats the purpose of an analytical database. Also prevents query merging — each node would be a separate roundtrip.
+
+**Raw SQL string templates**: Faster to prototype but impossible to merge queries, prone to SQL injection, and painful to maintain across dialects.
+
+**SQLAlchemy Core expressions**: Viable but lacks ClickHouse dialect support and the AST manipulation capabilities needed for query merging.
+
+## Consequences
+
+- **Positive**: Queries execute where the data lives (ClickHouse). Preview of 100 rows from a billion-row table scans only what's needed. Query merging reduces roundtrips.
+- **Positive**: SQL injection is structurally prevented — values are always parameterized through the AST.
+- **Negative**: SQLGlot has a learning curve. Contributors must understand AST manipulation, not just SQL strings.
+- **Negative**: Some node types (e.g., Formula with complex expressions) require careful AST construction.

--- a/docs/decisions/0002-multi-tenant-from-day-one.md
+++ b/docs/decisions/0002-multi-tenant-from-day-one.md
@@ -1,0 +1,35 @@
+# 0002: Multi-Tenant Architecture from Day One
+
+**Status:** Accepted
+**Date:** 2025-10-01
+**Deciders:** Architecture team
+
+## Context
+
+FlowForge needed to decide between single-tenant (one deployment per customer) and multi-tenant (shared deployment, data isolation via `tenant_id`). The application stores workflow metadata in PostgreSQL and queries analytical data from ClickHouse/Materialize/Redis.
+
+## Decision
+
+Multi-tenant from day one. Every tenant-scoped resource is isolated by a `tenant_id` UUID column. Tenant identity is derived exclusively from Keycloak JWT claims — never from client-supplied headers, URL parameters, or query strings.
+
+Key rules:
+- Every PostgreSQL query on tenant-scoped tables includes `WHERE tenant_id = :tenant_id`
+- Missing tenant filter = security bug
+- Cross-tenant access returns 404 (not 403) to prevent tenant enumeration
+- Cache keys (Redis) include `tenant_id`
+- WebSocket channels are tenant-scoped on the backend
+
+## Alternatives Considered
+
+**Single-tenant per deployment**: Simpler isolation but dramatically increases operational cost. Each customer would need their own infrastructure stack.
+
+**Schema-per-tenant (PostgreSQL schemas)**: Strong isolation but complicates migrations — every schema must be migrated independently. Doesn't work for ClickHouse/Materialize which don't have equivalent schema isolation.
+
+**Row-level security (PostgreSQL RLS)**: Considered as an additional layer but not used as the primary mechanism. Application-level filtering is more explicit and easier to test. RLS could be added later as defense-in-depth.
+
+## Consequences
+
+- **Positive**: Single deployment serves all tenants. Lower operational overhead.
+- **Positive**: Tenant isolation is explicit in code and testable — every service method takes `tenant_id` as a parameter.
+- **Negative**: Every query, cache key, and WebSocket channel must be tenant-aware. Missing a filter is a data leak.
+- **Negative**: Cross-tenant queries (admin analytics across all tenants) require special handling.

--- a/docs/decisions/0003-dual-schema-engines.md
+++ b/docs/decisions/0003-dual-schema-engines.md
@@ -1,0 +1,38 @@
+# 0003: Dual Schema Propagation Engines (TypeScript + Python)
+
+**Status:** Accepted
+**Date:** 2025-10-01
+**Deciders:** Architecture team
+
+## Context
+
+The canvas needs to show users real-time schema information as they build workflows — column names in dropdowns, type-appropriate operators, and instant error highlighting when incompatible nodes are connected. This requires computing the output schema of every node in the DAG after each change.
+
+The backend (Python) needs the same logic to validate workflows before compilation and to verify schema correctness server-side.
+
+## Decision
+
+Maintain **two schema propagation engines** that must produce identical results:
+
+1. **TypeScript** (`frontend/src/shared/schema/propagation.ts`) — synchronous, runs on every connection change, provides instant feedback. Target: < 10ms for 50 nodes.
+2. **Python** (`backend/app/services/schema_engine.py`) — authoritative, runs server-side for validation and compilation.
+
+Both engines are tested against 11 shared JSON fixtures in `tests/fixtures/schema/`. The `scripts/validate-schema-parity.sh` script verifies parity and runs in CI.
+
+## Alternatives Considered
+
+**Server-side only**: Every connection change triggers an API call. At 50-200ms round-trip, the canvas feels sluggish. Debouncing helps but introduces visible lag in dropdown population.
+
+**Client-side only**: Fast but the backend can't trust client-reported schemas. A malicious or buggy client could claim any schema, bypassing validation.
+
+**WASM compilation of a single engine**: Write once in Rust/Go, compile to WASM for the browser and native for the backend. Eliminates drift but adds build complexity and a third language to the stack.
+
+**Code generation from a shared DSL**: Define transforms in a neutral format, generate TypeScript and Python. Eliminates drift but the generator becomes a complex tool to maintain.
+
+## Consequences
+
+- **Positive**: Instant schema feedback in the canvas — dropdowns populate in < 10ms.
+- **Positive**: Server-side validation catches any client-side bugs or tampering.
+- **Positive**: Shared fixtures make drift detectable in CI before it reaches production.
+- **Negative**: Every new node type requires implementing the transform twice. The node type checklist has 6 files minimum.
+- **Negative**: Subtle behavioral differences between TypeScript and Python (floating point, null handling) can cause hard-to-debug parity failures.

--- a/docs/decisions/0004-read-only-serving-layer.md
+++ b/docs/decisions/0004-read-only-serving-layer.md
@@ -1,0 +1,29 @@
+# 0004: Application Treats the Serving Layer as Read-Only
+
+**Status:** Accepted
+**Date:** 2025-10-01
+**Deciders:** Architecture team
+
+## Context
+
+FlowForge queries data from ClickHouse, Materialize, and Redis. A separate data pipeline (Redpanda, Bytewax, dbt, Airflow) populates these stores. The question was whether the application should also write to the serving layer — e.g., creating materialized views, inserting computed results, or managing table schemas.
+
+## Decision
+
+The application treats the serving layer as **strictly read-only**. No DDL, INSERT, CREATE VIEW, or any write operation against ClickHouse, Materialize, or Redis (except cache writes to Redis for preview results).
+
+The serving layer contract is defined by table schemas that the pipeline maintains. The application reads from whatever the pipeline produces. The pipeline can be replaced, extended, or swapped out without changing the application — as long as the contract is maintained.
+
+## Alternatives Considered
+
+**Application-managed materialized views**: The app could create Materialize views on demand based on user workflows. This would allow truly custom real-time computations. Rejected because it couples the app to Materialize's lifecycle, makes the app responsible for view cleanup, and creates a blast radius where a bad user query could impact the shared Materialize cluster.
+
+**Write-through cache**: The app could write computed results back to ClickHouse for reuse. Rejected because it violates the clean separation between pipeline (writes) and application (reads), and complicates cache invalidation.
+
+## Consequences
+
+- **Positive**: Clean architectural boundary. The pipeline team and app team can work independently.
+- **Positive**: The app cannot corrupt the serving layer. Bad queries fail; they don't write bad data.
+- **Positive**: The pipeline can be replaced entirely (e.g., swap Bytewax for Flink) without touching the app.
+- **Negative**: The app cannot create custom materialized views for user workflows. All real-time views must be pre-defined by the pipeline.
+- **Negative**: Preview result caching uses Redis (a write), which is the one exception to the read-only rule.

--- a/docs/decisions/0005-content-addressed-preview-cache.md
+++ b/docs/decisions/0005-content-addressed-preview-cache.md
@@ -1,0 +1,35 @@
+# 0005: Content-Addressed Preview Cache with Three-Layer Protection
+
+**Status:** Accepted
+**Date:** 2025-11-01
+**Deciders:** Architecture team
+
+## Context
+
+When a user clicks a node on the canvas, the app shows a data preview (up to 100 rows). Naive implementation fires a query on every click, which is wasteful — users click rapidly between nodes, often revisiting nodes they've already previewed. Additionally, unfiltered previews against billion-row ClickHouse tables could overload the cluster.
+
+## Decision
+
+Three-layer preview protection:
+
+1. **Frontend debounce + cancellation**: 300ms debounce on node clicks. In-flight requests are aborted when the user clicks a different node. Eliminates 60-70% of unnecessary queries.
+
+2. **Content-addressed cache (Redis)**: Cache key is a hash of `(node_id, node_config, upstream_subgraph_configs[], schema_version)` — not the node ID alone. This means identical subgraph configurations share cache hits across users and sessions. Tenant isolation is inherent because compiled SQL includes tenant filters, making the cache key naturally tenant-scoped. TTL: 5 minutes.
+
+3. **Query sandboxing (ClickHouse settings)**: Every preview query is wrapped with `LIMIT 100`, `max_execution_time = 3s`, `max_memory_usage = 100MB`, `max_rows_to_read = 10M`. ClickHouse enforces these server-side. Queries exceeding limits return an error, not a timeout.
+
+## Alternatives Considered
+
+**Session-scoped cache (per-user)**: Simpler but wastes cache. Two users with identical workflows would each execute the same query. Content-addressed caching is naturally deduped.
+
+**No debounce, rely only on caching**: Cache misses still fire queries on rapid clicks. The debounce layer is cheap and prevents unnecessary cache lookups too.
+
+**Client-side caching only (TanStack Query)**: Doesn't protect the backend from redundant queries across different browser sessions.
+
+## Consequences
+
+- **Positive**: Rapid node clicking feels instant — most clicks hit cache or get debounced away.
+- **Positive**: Runaway queries are impossible — ClickHouse enforces resource limits server-side.
+- **Positive**: Cross-user cache sharing — identical workflows benefit from shared cache hits.
+- **Negative**: Cache key computation requires traversing the upstream subgraph, adding complexity to the preview service.
+- **Negative**: The 3-second query timeout means some complex previews fail. The frontend must handle this gracefully.

--- a/docs/decisions/0006-dashboards-as-workflow-projections.md
+++ b/docs/decisions/0006-dashboards-as-workflow-projections.md
@@ -1,0 +1,34 @@
+# 0006: Dashboards Are Projections of Workflows, Not Independent Queries
+
+**Status:** Accepted
+**Date:** 2025-11-01
+**Deciders:** Architecture team
+
+## Context
+
+Dashboard widgets need to display data. Two approaches:
+
+1. **Widgets reference workflow output nodes** — a widget points to a specific node in a workflow and executes its subgraph
+2. **Widgets have independent query definitions** — each widget has its own SQL/configuration separate from any workflow
+
+## Decision
+
+Dashboards are **projections of workflows**. A widget record stores `{ workflow_id, output_node_id, dashboard_id, layout, config_overrides }`. To render a widget, the system executes the workflow subgraph up to the pinned output node.
+
+Widgets are references to canvas output nodes — not copies. If the workflow changes, the widget output changes. The same chart component renders in all three contexts (canvas preview, dashboard widget, embed iframe).
+
+## Alternatives Considered
+
+**Independent widget queries**: Each widget has its own SQL definition, decoupled from workflows. Simpler mental model but creates two parallel systems for defining data transformations — the canvas and the widget editor. Users would need to learn both.
+
+**Snapshot-on-pin (copy the subgraph)**: When pinning, copy the relevant subgraph into the widget. Decouples the widget from future workflow changes. Rejected because it creates drift — the widget shows stale logic while the workflow has moved on, with no easy way to sync.
+
+**Materialized result sets**: Pre-compute widget data on a schedule and store results. Good for performance but adds a storage and scheduling layer, and live data widgets can't work this way.
+
+## Consequences
+
+- **Positive**: Single source of truth. Change the workflow, all widgets update.
+- **Positive**: One chart component library, used everywhere. No per-mode variants.
+- **Positive**: Users build logic once on the canvas, then expose it multiple ways.
+- **Negative**: Deleting or restructuring a workflow can break widgets. Orphaned widgets need explicit error states.
+- **Negative**: Widget rendering depends on workflow compilation — if the compiler has a bug, all widgets for that workflow break simultaneously.

--- a/docs/decisions/0007-query-merging.md
+++ b/docs/decisions/0007-query-merging.md
@@ -1,0 +1,33 @@
+# 0007: Mandatory Query Merging for Adjacent Compatible Nodes
+
+**Status:** Accepted
+**Date:** 2025-11-01
+**Deciders:** Architecture team
+
+## Context
+
+A typical canvas workflow has sequences of compatible SQL operations: Filter -> Select -> Sort, or Filter -> GroupBy -> Sort. Without optimization, each node would generate a separate query, and the system would execute them sequentially with intermediate result materialization.
+
+## Decision
+
+**Query merging is mandatory.** The workflow compiler identifies sequences of adjacent nodes that can be expressed as a single SQL query and merges them. For example:
+
+- `Filter -> Select -> Sort` = one `SELECT ... WHERE ... ORDER BY` query
+- `Filter -> GroupBy -> Sort` = one `SELECT ... WHERE ... GROUP BY ... ORDER BY` query
+
+The merge boundary is defined by node type compatibility. Nodes that change the query structure (Join, Union) or require separate execution (output nodes) break the merge chain.
+
+## Alternatives Considered
+
+**No merging (one query per node)**: Simplest to implement but generates unnecessary roundtrips. A 5-node linear workflow would execute 5 queries instead of 1. ClickHouse is fast but not free — network overhead and query planning add up.
+
+**Optional merging (optimization hint)**: Let the compiler decide when to merge based on heuristics. Rejected because it makes behavior unpredictable — the same workflow could generate different numbers of queries depending on optimizer decisions, making debugging harder.
+
+**CTE-based composition**: Express each node as a CTE (`WITH`), let the database optimizer merge them. ClickHouse's CTE optimization is limited compared to PostgreSQL, so this doesn't reliably reduce execution cost.
+
+## Consequences
+
+- **Positive**: Dramatically fewer queries. Most linear workflows compile to 1-3 queries regardless of node count.
+- **Positive**: ClickHouse processes the entire pipeline in one pass, leveraging its columnar scan optimizations.
+- **Negative**: The compiler must track merge state across nodes, adding complexity to `workflow_compiler.py`.
+- **Negative**: Debugging compiled SQL is harder when multiple nodes are merged — a bug in the Sort merge logic looks like a Filter bug in the output.

--- a/docs/decisions/CLAUDE.md
+++ b/docs/decisions/CLAUDE.md
@@ -1,0 +1,1 @@
+agents.md

--- a/docs/decisions/agents.md
+++ b/docs/decisions/agents.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records — Agent Rules
+
+> Parent rules: [`/workspace/docs/agents.md`](../agents.md)
+
+## Purpose
+
+Architecture Decision Records (ADRs) capture **why** key technical decisions were made. Each ADR is a short, immutable document recording the context, options considered, and rationale for a decision. They are numbered sequentially and never deleted — only superseded.
+
+## Format
+
+Every ADR follows this template (see `0000-template.md`):
+
+```markdown
+# NNNN: Title
+
+**Status:** Accepted | Superseded by [NNNN](./NNNN-title.md) | Deprecated
+**Date:** YYYY-MM-DD
+**Deciders:** Who was involved
+
+## Context
+What is the problem or situation that requires a decision?
+
+## Decision
+What is the change that we're making?
+
+## Consequences
+What becomes easier or harder as a result of this decision?
+```
+
+## Naming Convention
+
+`NNNN-kebab-case-title.md` — zero-padded to 4 digits, sequential, never reused.
+
+Examples: `0001-sqlglot-over-dataframes.md`, `0002-multi-tenant-from-day-one.md`
+
+## Lifecycle
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion — not yet decided |
+| **Accepted** | Decision made and in effect |
+| **Superseded** | Replaced by a newer ADR (link to it) |
+| **Deprecated** | No longer relevant (e.g., feature removed) |
+
+Accepted ADRs are **immutable** — do not edit them. If a decision changes, write a new ADR that supersedes the old one and update the old ADR's status line to `Superseded by [NNNN](./NNNN-title.md)`.
+
+## Rules
+
+- **One decision per ADR.** Don't combine multiple decisions into one document.
+- **Short and focused.** ADRs should be 1-2 pages max. Link to external docs for deep dives.
+- **Record the alternatives.** The value of an ADR is understanding *why* option B was chosen over A and C.
+- **Write ADRs when decisions are made**, not retroactively months later (though retroactive ADRs are better than none).
+- **Never delete an ADR.** The historical record is the point. Supersede instead.
+- **Number is permanent.** Even rejected proposals keep their number.

--- a/docs/rfcs/CLAUDE.md
+++ b/docs/rfcs/CLAUDE.md
@@ -1,0 +1,1 @@
+agents.md

--- a/docs/rfcs/agents.md
+++ b/docs/rfcs/agents.md
@@ -1,0 +1,62 @@
+# RFCs (Requests for Comments) — Agent Rules
+
+> Parent rules: [`/workspace/docs/agents.md`](../agents.md)
+
+## Purpose
+
+RFCs are **proposals for significant changes** that need discussion before implementation. Use an RFC when a change affects multiple components, introduces new architecture, or has multiple valid approaches that need evaluation.
+
+## When to Write an RFC
+
+- New features that touch 3+ directories or introduce new patterns
+- Changes to the serving layer contract or schema propagation engine
+- New infrastructure components (databases, message queues, external services)
+- Changes that would require updating `agents.md` rules
+
+## When NOT to Write an RFC
+
+- Bug fixes, small features, refactors within a single component
+- Changes that follow established patterns (e.g., adding a new node type using the existing checklist)
+- Anything already covered by an accepted ADR
+
+## Format
+
+```markdown
+# RFC-NNNN: Title
+
+**Status:** Draft | In Discussion | Accepted | Rejected | Withdrawn
+**Author:** Name
+**Date:** YYYY-MM-DD
+
+## Summary
+One paragraph: what and why.
+
+## Motivation
+Why is this change needed? What problem does it solve?
+
+## Detailed Design
+How would this work? Be specific enough that someone could implement it.
+
+## Alternatives Considered
+What other approaches were evaluated? Why were they rejected?
+
+## Open Questions
+What still needs to be resolved?
+```
+
+## Lifecycle
+
+1. **Draft** — Author writes the RFC
+2. **In Discussion** — Team reviews (via PR or direct discussion)
+3. **Accepted** — Decision made; key choices recorded as ADRs in `docs/decisions/`
+4. **Rejected/Withdrawn** — Not proceeding; document kept for historical record
+
+## Naming Convention
+
+`NNNN-kebab-case-title.md` — same numbering scheme as ADRs but in a separate sequence.
+
+## Rules
+
+- **RFCs produce ADRs.** When an RFC is accepted, extract the key decisions into one or more ADRs in `docs/decisions/`.
+- **Keep RFCs after acceptance.** They provide richer context than the ADR alone.
+- **Don't use RFCs as task lists.** RFCs describe *what* and *why*, not *how to implement step by step*. Implementation plans belong in GitHub issues or project boards.


### PR DESCRIPTION
## Summary

Set up formal documentation organization following the Architecture Decision Records (ADR) pattern, with an RFC process for future proposals.

### New directories

| Directory | Purpose | Lifecycle |
|-----------|---------|-----------|
| `docs/decisions/` | ADRs — immutable records of *why* key decisions were made | Accepted -> Superseded (never edited) |
| `docs/rfcs/` | Proposals for significant changes needing discussion | Draft -> Accepted/Rejected |

Both include `agents.md` + `CLAUDE.md` symlinks with rules, naming conventions, and lifecycle documentation.

### 7 seed ADRs (extracted from actual project decisions)

| # | Decision |
|---|----------|
| 0001 | SQLGlot over DataFrames for query compilation |
| 0002 | Multi-tenant architecture from day one |
| 0003 | Dual schema propagation engines (TypeScript + Python) |
| 0004 | Read-only serving layer boundary |
| 0005 | Content-addressed preview cache with three-layer protection |
| 0006 | Dashboards as workflow projections, not independent queries |
| 0007 | Mandatory query merging for adjacent compatible nodes |

### Updated files

- `docs/agents.md` — added document type taxonomy (Reference Guides, ADRs, RFCs, Archive)
- `README.md` — updated project structure tree and documentation index
- `agents.md` — header links now point to decisions/, rfcs/, archive/

## Test plan

- [x] ADR template (`0000-template.md`) follows standard format
- [x] All 7 ADRs accurately reflect implemented architecture
- [x] `agents.md` files clearly distinguish ADR lifecycle from RFC lifecycle
- [x] CLAUDE.md symlinks resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)