### PR TITLE
docs: add ADR/RFC to Focused Guides table

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -73,6 +73,8 @@ Compiles workflows to SQL against a **read-only** serving layer (ClickHouse, Mat
 
 | Topic | Document |
 |-------|----------|
+| Architecture decisions (ADRs) — why key choices were made | [`docs/decisions/`](./docs/decisions/) |
+| Proposals for significant changes (RFCs) | [`docs/rfcs/`](./docs/rfcs/) |
 | Node types, checklist, schema propagation, query merging | [`docs/node-type-guide.md`](./docs/node-type-guide.md) |
 | Multi-tenancy rules, code patterns, tenant isolation | [`docs/multi-tenancy.md`](./docs/multi-tenancy.md) |
 | Serving layer tables, query router, SQL dialects | [`docs/serving-layer.md`](./docs/serving-layer.md) |


### PR DESCRIPTION
## Summary

- Add `docs/decisions/` and `docs/rfcs/` to the Focused Guides table in root `agents.md`
- This is the primary discovery point for cross-cutting docs — the ADR structure was linked in the header but missing from this table

One-line change to close the gap from PR #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)