### PR TITLE
feat(ui): prompt for name when creating dashboards and workflows

### DIFF
--- a/frontend/src/features/canvas/components/WorkflowPicker.tsx
+++ b/frontend/src/features/canvas/components/WorkflowPicker.tsx
@@ -52,9 +52,7 @@ export default function WorkflowPicker() {
       {showCreate && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-canvas-node border border-canvas-border rounded-lg p-4 w-80">
-            <h3 className="text-sm font-medium text-white mb-3">
-              Create Workflow
-            </h3>
+            <h3 className="text-sm font-medium text-white mb-3">Create Workflow</h3>
             <input
               autoFocus
               type="text"

--- a/frontend/src/features/dashboards/components/DashboardPicker.tsx
+++ b/frontend/src/features/dashboards/components/DashboardPicker.tsx
@@ -41,9 +41,7 @@ export default function DashboardPicker() {
       {showCreate && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-canvas-node border border-canvas-border rounded-lg p-4 w-80">
-            <h3 className="text-sm font-medium text-white mb-3">
-              Create Dashboard
-            </h3>
+            <h3 className="text-sm font-medium text-white mb-3">Create Dashboard</h3>
             <input
               autoFocus
               type="text"


### PR DESCRIPTION
## Summary

- **DashboardPicker**: "New Dashboard" button now opens a modal with a name input instead of immediately creating with a hardcoded name
- **WorkflowPicker**: "New Workflow" button now opens the same style modal for naming before creation
- Both support Enter to confirm, Escape to dismiss, and fall back to default names if left blank

## Test plan

- [ ] Click "New Dashboard" → modal appears with name input, autofocused
- [ ] Type a name and press Enter → dashboard created with that name
- [ ] Leave blank and click Create → dashboard created as "New Dashboard"
- [ ] Press Escape → modal dismissed, no dashboard created
- [ ] Same flow for "New Workflow" on the canvas picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)