### PR TITLE
feat(pipeline): add raw sink with live WebSocket updates

### DIFF
--- a/pipeline/agents.md
+++ b/pipeline/agents.md
@@ -17,6 +17,7 @@ The data pipeline generates synthetic market data and transforms it into the ser
 | `generator/` | Data Generator | Python | Synthetic trades + quotes → Redpanda topics |
 | `bytewax/flows/vwap.py` | VWAP Flow | Bytewax | 5-min VWAP windows → ClickHouse + Redis |
 | `bytewax/flows/volatility.py` | Volatility Flow | Bytewax | Rolling 1h/24h volatility → ClickHouse + Redis |
+| `bytewax/flows/raw_sink.py` | Raw Sink | Bytewax | Raw trades + quotes → ClickHouse + Redis broadcast |
 | `bytewax/flows/anomaly.py` | Anomaly Flow | Bytewax | Spread/volume/price anomaly detection → alerts |
 | `dbt/` | Batch Transforms | dbt | Staging → intermediate → mart models in ClickHouse |
 | `airflow/` | Orchestration | Airflow | dbt DAG scheduling |
@@ -30,6 +31,25 @@ The pipeline provides data to these stores that FlowForge reads:
 | ClickHouse | `raw_trades`, `raw_quotes`, `vwap_5min`, `rolling_volatility`, `hourly_rollup`, `daily_rollup`, `fct_trades`, `dim_instruments`, `rpt_daily_pnl` | Seconds to hours |
 | Materialize | `live_positions`, `live_quotes`, `live_pnl` | Sub-second |
 | Redis | `latest:vwap:*`, `latest:position:*` | Seconds |
+
+## Live Update Path (Raw Sink → Dashboard WebSocket)
+
+The raw sink flow connects the streaming pipeline to the FlowForge dashboard in real time:
+
+```
+Generator → Redpanda topics → raw_sink batch flush → ClickHouse INSERT
+                                                    → Redis PUBLISH "flowforge:broadcast:table_update"
+                                                         ↓
+                                                    Backend WebSocket manager (catches :broadcast:)
+                                                         ↓
+                                                    ALL connected dashboard clients
+                                                         ↓
+                                                    useWidgetData invalidates → re-fetches from ClickHouse
+```
+
+- **Batch size**: 50 records per flush. At 10 trades/s + 50 quotes/s, updates fire roughly every 1-5 seconds.
+- **Redis channel**: `flowforge:broadcast:table_update` — not tenant-scoped because the pipeline has no tenant context. The WebSocket manager broadcasts to all connected clients.
+- **Frontend**: Widgets in "live" mode (`auto_refresh_interval: -1`) listen for `table_update` messages and invalidate their TanStack Query cache.
 
 ## Rules
 

--- a/pipeline/bytewax/flows/raw_sink.py
+++ b/pipeline/bytewax/flows/raw_sink.py
@@ -1,0 +1,117 @@
+"""
+Raw data sink — consumes raw.trades and raw.quotes from Redpanda
+and inserts them into ClickHouse flowforge.raw_trades / flowforge.raw_quotes.
+
+The Bytewax VWAP and Volatility flows only write aggregated data.
+This flow writes the raw events so they're queryable in the canvas.
+"""
+import os
+import json
+from datetime import datetime
+
+import bytewax.operators as op
+from bytewax.dataflow import Dataflow
+from bytewax.connectors.kafka import KafkaSource
+from bytewax.connectors.stdio import StdOutSink
+from confluent_kafka import OFFSET_END
+
+import clickhouse_connect
+import redis
+
+REDPANDA_BROKERS = os.environ.get("REDPANDA_BROKERS", "redpanda:29092").split(",")
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", "8123"))
+REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
+REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
+
+BATCH_SIZE = 50
+
+ch_client = clickhouse_connect.get_client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT)
+r_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT)
+
+# Buffers for batched inserts
+trade_buffer: list[list] = []
+quote_buffer: list[list] = []
+
+
+def route_message(msg):
+    """Parse message and tag with topic."""
+    data = json.loads(msg.value)
+    topic = msg.topic
+    return (topic, data)
+
+
+def sink_record(topic_data):
+    """Buffer and batch-insert records into ClickHouse."""
+    topic, data = topic_data
+
+    if topic == "raw.trades":
+        event_time = datetime.fromisoformat(data["event_time"])
+        price = float(data["price"])
+        quantity = float(data["quantity"])
+        trade_buffer.append([
+            data["trade_id"],
+            event_time,
+            data["symbol"],
+            data["side"],
+            quantity,
+            price,
+            round(price * quantity, 4),
+        ])
+
+        if len(trade_buffer) >= BATCH_SIZE:
+            ch_client.insert(
+                "flowforge.raw_trades",
+                trade_buffer,
+                column_names=["trade_id", "event_time", "symbol", "side",
+                              "quantity", "price", "notional"],
+            )
+            trade_buffer.clear()
+            r_client.publish(
+                "flowforge:broadcast:table_update",
+                json.dumps({"type": "table_update", "table": "raw_trades"}),
+            )
+
+    elif topic == "raw.quotes":
+        event_time = datetime.fromisoformat(data["event_time"])
+        bid = float(data["bid"])
+        ask = float(data["ask"])
+        quote_buffer.append([
+            data["symbol"],
+            event_time,
+            bid,
+            ask,
+            float(data["bid_size"]),
+            float(data["ask_size"]),
+            round((bid + ask) / 2, 6),
+        ])
+
+        if len(quote_buffer) >= BATCH_SIZE:
+            ch_client.insert(
+                "flowforge.raw_quotes",
+                quote_buffer,
+                column_names=["symbol", "event_time", "bid", "ask",
+                              "bid_size", "ask_size", "mid_price"],
+            )
+            quote_buffer.clear()
+            r_client.publish(
+                "flowforge:broadcast:table_update",
+                json.dumps({"type": "table_update", "table": "raw_quotes"}),
+            )
+
+    return (topic, data.get("symbol", "?"))
+
+
+# Build the dataflow
+flow = Dataflow("raw_sink")
+
+source = KafkaSource(
+    brokers=REDPANDA_BROKERS,
+    topics=["raw.trades", "raw.quotes"],
+    starting_offset=OFFSET_END,
+)
+
+stream = op.input("raw_in", flow, source)
+routed = op.map("route", stream, route_message)
+sunk = op.map("sink", routed, sink_record)
+op.output("log", sunk, StdOutSink())

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -198,6 +198,18 @@ start_bytewax_volatility() {
     log_success "Bytewax Volatility started (PID $(cat $PID_DIR/bytewax-volatility.pid))"
 }
 
+start_bytewax_raw_sink() {
+    log_info "Starting Bytewax Raw Sink flow..."
+    cd "$WORKSPACE_DIR/pipeline/bytewax"
+
+    REDPANDA_BROKERS="${REDPANDA_BROKERS}" \
+    CLICKHOUSE_HOST="${CLICKHOUSE_HOST}" \
+    python3 -m bytewax.run flows.raw_sink > "$PID_DIR/bytewax-raw-sink.log" 2>&1 &
+    echo $! > "$PID_DIR/bytewax-raw-sink.pid"
+
+    log_success "Bytewax Raw Sink started (PID $(cat $PID_DIR/bytewax-raw-sink.pid))"
+}
+
 start_backend() {
     log_info "Starting FastAPI backend..."
     cd "$WORKSPACE_DIR/backend"
@@ -304,6 +316,7 @@ main() {
 
     start_bytewax_vwap
     start_bytewax_volatility
+    start_bytewax_raw_sink
 
     start_backend
     start_frontend


### PR DESCRIPTION
## Summary
- **New Bytewax raw_sink flow** (`pipeline/bytewax/flows/raw_sink.py`): Consumes `raw.trades` and `raw.quotes` from Redpanda, batch-inserts into ClickHouse, and publishes `table_update` notifications to Redis
- **Live dashboard updates**: WebSocket manager broadcasts `table_update` messages to all connected clients; frontend widgets in "live" mode auto-invalidate their TanStack Query cache
- **Pipeline startup**: raw_sink added to `start-pipeline.sh` orchestration

## Changes
| File | Change |
|------|--------|
| `pipeline/bytewax/flows/raw_sink.py` | New Bytewax flow: Redpanda → ClickHouse + Redis PUBLISH |
| `backend/app/services/websocket_manager.py` | Add `_broadcast_to_all()` + broadcast channel routing |
| `frontend/src/features/dashboards/hooks/useWidgetData.ts` | Subscribe to `table_update` messages for live cache invalidation |
| `scripts/start-pipeline.sh` | Add `start_bytewax_raw_sink()` to pipeline startup |
| `pipeline/agents.md` | Document raw_sink component + live update path |

## Live Update Path
```
Generator → Redpanda → raw_sink batch flush → ClickHouse INSERT
                                             → Redis PUBLISH "flowforge:broadcast:table_update"
                                                  ↓
                                             WebSocket manager (_broadcast_to_all)
                                                  ↓
                                             ALL connected dashboard clients
                                                  ↓
                                             useWidgetData invalidates → re-fetches from ClickHouse
```

## Test plan
- [ ] Start pipeline with `./scripts/start-pipeline.sh` — raw_sink starts alongside other flows
- [ ] Verify raw_trades/raw_quotes in ClickHouse receive new rows within seconds
- [ ] Open dashboard with raw_trades widget in live mode — data updates automatically
- [ ] Check WebSocket messages in browser DevTools — `table_update` messages arrive on each batch flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)