### PR TITLE
fix(frontend): format FilterPanel.tsx with Prettier

### DIFF
--- a/frontend/src/features/canvas/panels/FilterPanel.tsx
+++ b/frontend/src/features/canvas/panels/FilterPanel.tsx
@@ -78,13 +78,17 @@ export default function FilterPanel({ nodeId }: Props) {
           <input
             type="datetime-local"
             value={betweenParts[0]}
-            onChange={(e) => updateNodeConfig(nodeId, { value: `${e.target.value},${betweenParts[1]}` })}
+            onChange={(e) =>
+              updateNodeConfig(nodeId, { value: `${e.target.value},${betweenParts[1]}` })
+            }
             className="w-full bg-canvas-bg border border-white/10 rounded px-2 py-1.5 text-sm text-white"
           />
           <input
             type="datetime-local"
             value={betweenParts[1]}
-            onChange={(e) => updateNodeConfig(nodeId, { value: `${betweenParts[0]},${e.target.value}` })}
+            onChange={(e) =>
+              updateNodeConfig(nodeId, { value: `${betweenParts[0]},${e.target.value}` })
+            }
             className="w-full bg-canvas-bg border border-white/10 rounded px-2 py-1.5 text-sm text-white"
           />
         </div>


### PR DESCRIPTION
## Summary
- Fix Prettier formatting on `FilterPanel.tsx` (datetime picker changes from PR #32)
- This was causing the Frontend CI check to fail on PR #33

## Test plan
- [x] `npx prettier --check src/` passes
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — all 115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)