### PR TITLE
chore(ci): require all CI checks to pass before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    continue-on-error: true  # Optional: doesn't block PR merge
 
     services:
       db:
@@ -169,3 +168,25 @@ jobs:
       - name: Test
         run: npx vitest run --passWithNoTests
         working-directory: frontend
+
+  gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [backend, frontend, integration]
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ needs.backend.result }}" != "success" ]]; then
+            echo "Backend failed: ${{ needs.backend.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.frontend.result }}" != "success" ]]; then
+            echo "Frontend failed: ${{ needs.frontend.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.integration.result }}" != "success" ]]; then
+            echo "Integration Tests failed: ${{ needs.integration.result }}"
+            exit 1
+          fi
+          echo "All CI checks passed"


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from Integration Tests — failures now block merges
- Add **CI Gate** job that depends on all 3 checks (Backend, Frontend, Integration Tests) and fails if any of them fail
- Enable branch protection on `main` requiring CI Gate to pass before merge
- `enforce_admins: true` — nobody can bypass, including repo owners
- Made repo public to enable branch protection (free plan limitation)

## How it works
```
Backend ──────┐
Frontend ─────┼──→ CI Gate (requires all 3 = success) ──→ branch protection ──→ merge allowed
Integration ──┘
```

The merge button on GitHub is disabled until CI Gate passes.

## Test plan
- [ ] This PR itself should show 4 checks: Backend, Frontend, Integration Tests, CI Gate
- [ ] CI Gate only goes green after all 3 jobs pass
- [ ] Merge button is disabled until CI Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)